### PR TITLE
refactor(config): remove distDir from next.config and update build co…

### DIFF
--- a/docs/vercel-static-export.md
+++ b/docs/vercel-static-export.md
@@ -1,0 +1,55 @@
+# Deploying Next.js Static Exports to Vercel
+
+This document explains how to deploy a Next.js application with static exports (`output: 'export'`) to Vercel.
+
+## The Problem
+
+When using `output: 'export'` in Next.js, the application is built as a static site without server components. However, Vercel's default Next.js deployment expects certain files like `routes-manifest.json` that are not generated in static export mode.
+
+## The Solution
+
+We've implemented the following changes to make the static export compatible with Vercel:
+
+1. **Updated `next.config.mjs`**:
+   - Removed `distDir: 'out'` as it conflicts with `output: 'export'`
+   - Kept `output: 'export'` to generate static files
+
+2. **Updated `vercel.json`**:
+   - Changed `framework` from `"nextjs"` to `null` to tell Vercel not to use its Next.js-specific handling
+   - Set `buildCommand` to `"npm run vercel-build"` to use our custom build script
+   - Kept `outputDirectory: "out"` to specify where the built files are located
+
+3. **Added a custom build script**:
+   - Created `scripts/prepare-vercel-deploy.js` that generates a minimal `routes-manifest.json` file
+   - Added a `vercel-build` script to package.json that runs the build and then the preparation script
+
+## How It Works
+
+1. When Vercel runs the build, it executes `npm run vercel-build`
+2. This runs `next build` to generate the static export in the `out` directory
+3. Then it runs `node scripts/prepare-vercel-deploy.js` which creates the missing `routes-manifest.json` file
+4. Vercel serves the static files from the `out` directory
+
+## API Routes in Static Exports
+
+Remember that in a static export, API routes don't function as true server endpoints. They are included in the JavaScript bundle and run on the client side. All API routes must include:
+
+```typescript
+export const dynamic = 'force-static';
+```
+
+## Limitations
+
+With this setup, there are some limitations:
+
+1. No server-side rendering
+2. No API routes (they're included in the bundle but don't function as true server endpoints)
+3. No middleware functionality
+4. No incremental static regeneration
+
+## Benefits
+
+1. Faster page loads (fully static)
+2. Can be deployed to any static hosting provider
+3. Lower hosting costs
+4. Better reliability (no server to go down) 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,6 @@ try {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   trailingSlash: true,
-  distDir: 'out',
   skipTrailingSlashRedirect: true,
   eslint: {
     ignoreDuringBuilds: true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "export": "next build"
+    "export": "next build",
+    "vercel-build": "next build && node scripts/prepare-vercel-deploy.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/prepare-vercel-deploy.js
+++ b/scripts/prepare-vercel-deploy.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+// Check if the out directory exists
+const outDir = path.join(__dirname, '..', 'out');
+if (!fs.existsSync(outDir)) {
+  console.error('Error: out directory does not exist. Run npm run build first.');
+  process.exit(1);
+}
+
+// Create an empty routes-manifest.json file if it doesn't exist
+// This is a workaround for Vercel deployment with static exports
+const routesManifestPath = path.join(outDir, 'routes-manifest.json');
+if (!fs.existsSync(routesManifestPath)) {
+  console.log('Creating empty routes-manifest.json for Vercel compatibility');
+  fs.writeFileSync(routesManifestPath, JSON.stringify({
+    version: 3,
+    basePath: "",
+    pages404: true,
+    redirects: [],
+    headers: [],
+    dynamicRoutes: [],
+    staticRoutes: [],
+    dataRoutes: [],
+    rewrites: []
+  }, null, 2));
+}
+
+console.log('Vercel deployment preparation complete!'); 

--- a/vercel.json
+++ b/vercel.json
@@ -29,8 +29,8 @@
       ]
     }
   ],
-  "buildCommand": "npm run build",
-  "framework": "nextjs",
+  "buildCommand": "npm run vercel-build",
+  "framework": null,
   "outputDirectory": "out",
   "trailingSlash": true,
   "cleanUrls": true


### PR DESCRIPTION
This pull request introduces changes to enable deploying a Next.js application with static exports (`output: 'export'`) to Vercel. Key updates include modifying configuration files, adding a custom build script, and documenting the deployment process and limitations.

### Configuration Updates for Vercel Compatibility:
* **`next.config.mjs`**: Removed `distDir: 'out'` to avoid conflicts with `output: 'export'`.
* **`vercel.json`**: Changed `framework` from `"nextjs"` to `null` and updated `buildCommand` to `"npm run vercel-build"` to use the custom build script.

### Custom Build Script:
* **`scripts/prepare-vercel-deploy.js`**: Added a script to create a minimal `routes-manifest.json` file required for Vercel deployment.

### Package Script Updates:
* **`package.json`**: Introduced a `vercel-build` script that runs `next build` followed by the custom preparation script.

### Documentation:
* **`docs/vercel-static-export.md`**: Added a detailed guide explaining the problem, solution, limitations, and benefits of deploying static exports to Vercel.…mmand for Vercel deployment